### PR TITLE
fix kitty syntax highlighting for synthwave theme

### DIFF
--- a/Configs/.config/hyde/themes/Synth Wave/kitty.theme
+++ b/Configs/.config/hyde/themes/Synth Wave/kitty.theme
@@ -1,59 +1,61 @@
 $HOME/.config/kitty/theme.conf|killall -SIGUSR1 kitty
 
+# Synthwave '84-inspired Kitty Theme
+
 # The basic colors
-foreground              #ffffff
-background              #262335
-selection_foreground    #262335
-selection_background    #f97e72
+foreground              #e2e8ff
+background              #2a2139
+selection_foreground    #2a2139
+selection_background    #f9c5d1
 
 # Cursor colors
-cursor                  #f97e72
-cursor_text_color       #262335
+cursor                  #ff70a6
+cursor_text_color       #2a2139
 
 # URL underline color when hovering with mouse
-url_color               #f97e72
+url_color               #ff70a6
 
 # OS Window titlebar colors
-wayland_titlebar_color system
-macos_titlebar_color system
+wayland_titlebar_color  system
+macos_titlebar_color    system
 
 # Colors for marks (marked text in the terminal)
-mark1_foreground #262335
-mark1_background #614D85
-mark2_foreground #262335
-mark2_background #614D85
-mark3_foreground #262335
-mark3_background #614D85
+mark1_foreground #2a2139
+mark1_background #7d4eae
+mark2_foreground #2a2139
+mark2_background #7d4eae
+mark3_foreground #2a2139
+mark3_background #7d4eae
 
 # The 16 terminal colors
 
 # black
-color0 #232530
-color8 #232530
+color0 #1a1b27
+color8 #3c3f58
 
 # red
-color1 #fe4450
-color9 #fe4450
+color1 #ff517d
+color9 #ff517d
 
 # green
-color2  #72f1b8
-color10 #72f1b8
+color2  #8cffd1
+color10 #8cffd1
 
 # yellow
-color3  #ff7edb
-color11 #ff7edb
+color3  #ff87d4
+color11 #ff87d4
 
 # blue
-color4  #03edf9
-color12 #03edf9
+color4  #65baff
+color12 #65baff
 
 # magenta
 color5  #fede5d
-color13 #f3e70f
+color13 #ffd36e
 
 # cyan
-color6  #03edf9
-color14 #03edf9
+color6  #78faff
+color14 #78faff
 
 # white
 color7  #ffffff


### PR DESCRIPTION
Before : 
![241111_11h31m22s_screenshot](https://github.com/user-attachments/assets/fb7bd84f-72e4-48f3-ae3b-4162134dadad)


After :
![241111_11h32m03s_screenshot](https://github.com/user-attachments/assets/0b2b776c-92dc-48c7-b4b0-95fa9997b410)

kept the colors as close to the synthwave color palette as possible 

please check if it needs any more changes