### PR TITLE
Add GTK_THEME environment variable for libadwaita apps theming

### DIFF
--- a/Configs/.config/hyde/themes/Rosé Pine/hypr.theme
+++ b/Configs/.config/hyde/themes/Rosé Pine/hypr.theme
@@ -12,6 +12,8 @@ exec = gsettings set org.gnome.desktop.interface icon-theme $ICON_THEME
 exec = gsettings set org.gnome.desktop.interface gtk-theme $GTK_THEME
 exec = gsettings set org.gnome.desktop.interface color-scheme $COLOR_SCHEME
 
+env = GTK_THEME,$GTK_THEME
+
 general {
     gaps_in = 3
     gaps_out = 8


### PR DESCRIPTION
# Description

This is copy of same PR I have done to the Prasanth's original repo

Apps created using libadvaita do not use GTK theme till the `GTK_THEME` is not set.

Examples of such apps can be `gedit`, `qualculate` or file open dialog called by `Ctrl+O` in chrome, vscode and I assume a lot more apps.

This behaviour is mentioned in [Arch Wiki](https://wiki.archlinux.org/title/GTK#GTK_3_and_GTK4)

> Note: For libadwaita-based GTK 4 applications, the chosen GTK theme needs [special support](https://github.com/jnsh/arc-theme/issues/61#issuecomment-922380704) and you are required to force a GTK theme with the GTK_THEME [environment variable](https://wiki.archlinux.org/title/Environment_variable)

I have added hypr env variable to this theme, and it works for me. If this PR will be approved, I'll create same PRs for other themes.

# Before

![241111_18h23m28s_screenshot](https://github.com/user-attachments/assets/ac53c730-e9d3-43c5-8a22-770f945f8b0f)

# After

![241111_18h33m32s_screenshot](https://github.com/user-attachments/assets/d53a9e6f-d4b3-4749-9f0f-e302298c9092)
