### PR TITLE
fix: update waybar layerrule syntax

### DIFF
--- a/Configs/.config/hyde/themes/Catppuccin Latte/hypr.theme
+++ b/Configs/.config/hyde/themes/Catppuccin Latte/hypr.theme
@@ -43,4 +43,4 @@ decoration {
     }
 }
 
-layerrule = blur,waybar
+layerrule = blur on, match:namespace waybar


### PR DESCRIPTION
Fixed syntax error for Waybar blur. The previous syntax 'blur,waybar' caused an error 'blur needs argument' in recent Hyprland versions. Updated to 'blur on, match:namespace waybar'.